### PR TITLE
First batch of (old) PRs

### DIFF
--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -1,15 +1,25 @@
 # To close
+- pybind/pybind11#1138
 - ...
 
 # Fixes
+- pybind/pybind11#1043
+- pybind/pybind11#1084
 - ...
 
 # Minor
+- pybind/pybind11#1089
+- pybind/pybind11#1101
 - ...
 
 # Major
+- pybind/pybind11#781
+- pybind/pybind11#1131
 - ...
 
 # To review
+- pybind/pybind11#1098
+- pybind/pybind11#1122
+- pybind/pybind11#1161
 - ...
 

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -1,25 +1,26 @@
 # To close
-- pybind/pybind11#1138
-- ...
+- pybind/pybind11#1138 - Inconsistent use of holder classes mess. Seems superseded by #1161. Either this or #1161 should get a more detailed review, before categorizing.
+
 
 # Fixes
-- pybind/pybind11#1043
-- pybind/pybind11#1084
-- ...
+- pybind/pybind11#1084 - Bug fix. Reviewed - looks fine to merge. Needs to be rebased, though.
+
 
 # Minor
-- pybind/pybind11#1089
-- pybind/pybind11#1101
-- ...
+- pybind/pybind11#1043 - Something about propagation of return policies. Removes 4 lines, should be safe, but there's a possibility that tests just don't cover what those 4 lines are doing.
+- pybind/pybind11#1089 - Cmake C++ standard version settings. Turned into bikeshedding about cmake versions and whether cmake 3.3 is too new (in 2017). Good candidate for merge. 
+- pybind/pybind11#1101 - Slicing with None. Simple enough, but blocked on repetition of code because `cast()` is not available and @henryiii claims forward declaration to be tricky.
+
 
 # Major
-- pybind/pybind11#781
-- pybind/pybind11#1131
-- ...
+- pybind/pybind11#1131 - Override overload order with `py::prepend()`. Jakob raised a concern about performance, but without backing it with numbers. Otherwise, no complaints and ready to be merged.
+
+
+## Unfinished
+- pybind/pybind11#781 - Far from finished. Seems very useful. I tried finishing it, but got stuck. Having a "lock into `py::class_` after `.def`" makes it hard to get done.
+
 
 # To review
-- pybind/pybind11#1098
-- pybind/pybind11#1122
-- pybind/pybind11#1161
-- ...
-
+- pybind/pybind11#1098 - Cmake compiler features, by @henryiii. I haven't given it a proper review.
+- pybind/pybind11#1122 - Construct `py::enum_` from std::string. A simple feature turned into a discussion about case sensitivity. I'm questioning the usefulness of the PR.
+- pybind/pybind11#1161 - Look at #1138 


### PR DESCRIPTION
Considering https://github.com/YannickJadoul/pybind11-cleanup/issues/1#issuecomment-481280985:

- sounds like 1043 is good to go.
- 1101 sounds like the forward declaration would be more work than justifiable (though that could be up for a debate).
- I personally have no use for constructing enums from strings, but that's just me. Either way, I don't think case insensitivity is a good idea and I think that some kind of policies for that would be an overkill.
- 1131 also sounds like it is good to go.